### PR TITLE
Support independent keys in a register workload

### DIFF
--- a/src/tarantool/client.clj
+++ b/src/tarantool/client.clj
@@ -6,7 +6,7 @@
             [dom-top.core :as dt]
             [next.jdbc.connection :as connection]))
 
-(def max-timeout "Longest timeout, in ms" 300000)
+(def max-timeout "Longest timeout, in ms" 10000000)
 
 (defn conn-spec
    "JDBC connection spec for a node."


### PR DESCRIPTION
Independent keys requires option --concurrency with minimal value 10.
`max-timeout` has been increased to be able to run 100 concurrent threads.

Closes #39