### PR TITLE
Remove counter-dec workload

### DIFF
--- a/src/tarantool/counter.clj
+++ b/src/tarantool/counter.clj
@@ -1,5 +1,5 @@
 (ns tarantool.counter
-  "Incrementing and decrementing a counter."
+  "Incrementing a counter."
   (:require [jepsen [client :as client]
                     [checker :as checker]
                     [generator :as gen]
@@ -83,12 +83,3 @@
    :checker   (checker/compose
                 {:timeline (timeline/html)
                  :counter  (checker/counter)})})
-
-(defn workload-dec
-  [opts]
-  (assoc (workload-inc opts)
-    :generator (->> (take 100 (cycle [add sub]))
-                    (cons r)
-                    gen/mix
-                    (gen/delay 1/10)
-                    (with-op-index))))

--- a/src/tarantool/runner.clj
+++ b/src/tarantool/runner.clj
@@ -42,7 +42,6 @@
   a keyword here instead."
   {:set             sets/workload
    :counter-inc     counter/workload-inc
-   :counter-dec     counter/workload-dec
    ;:bank            bank/workload
    ;:bank-index      bank/index-workload
    ;:g2              g2/workload
@@ -58,7 +57,7 @@
 
 (def workloads-expected-to-pass
   "A collection of workload names which we expect should actually pass."
-  (remove #{:counter-dec} standard-workloads))
+  (remove #{} standard-workloads))
 
 (def workload-options
   "For each workload, a map of workload options to all the values that option


### PR DESCRIPTION
checker/counter does not support decrements and in Jepsen 0.2.1
it throws when provided negative increments.

Closes #60