### PR TITLE
Disable counter-inc

### DIFF
--- a/src/tarantool/runner.clj
+++ b/src/tarantool/runner.clj
@@ -54,9 +54,11 @@
   (remove #{} (keys workloads)))
 
 (def workloads-expected-to-pass
-  "A collection of workload names which we expect should actually pass.
-  https://github.com/tarantool/jepsen.tarantool/issues/83"
-  (remove #{:bank :bank-multitable} standard-workloads))
+  "A collection of workload names which we expect should actually pass."
+  (remove #{:bank               ; https://github.com/tarantool/jepsen.tarantool/issues/83
+            :bank-multitable    ; https://github.com/tarantool/jepsen.tarantool/issues/83
+            :counter-inc        ; https://github.com/tarantool/tarantool/issues/6095
+            } standard-workloads))
 
 (def nemeses
   "Types of faults a nemesis can create."


### PR DESCRIPTION
counter-inc test is disabled by default for running with 'test-all'
option due to a bug in Tarantool [1].

1. https://github.com/tarantool/tarantool/issues/6095

Part of: #84