### PR TITLE
Mark a singleton instance as a leader manually

### DIFF
--- a/resources/tarantool/jepsen.lua
+++ b/resources/tarantool/jepsen.lua
@@ -29,6 +29,13 @@ else
 end
 
 local function bootstrap()
+    -- We don't use automatic leader election in the single instance
+    -- configuration, so we should manually mark this instance as
+    -- a leader for synchronous transactions processing.
+    if single_mode then
+        box.ctl.promote()
+    end
+
     box.schema.user.create('jepsen', {password = 'jepsen'})
     box.schema.user.grant('jepsen', 'create,read,write,execute,drop,alter,replication', 'universe')
     box.schema.user.grant('jepsen', 'read,write', 'space', '_index')


### PR DESCRIPTION
Otherwise 'set' and 'register' tests, which use synchronous spaces, fail
with the 'The synchronous transaction queue doesn't belong to any
instance' error.

Those tests did pass before the change [1] in tarantool, which was made 
in the scope of the issue [2]. The commit land into release branches as
2.7.2-160-g7310288fa, 2.8.1-168-g806123567, 2.9.0-221-g362e9a668.

[1]: https://github.com/tarantool/tarantool/commit/362e9a6684e899ad33bcc8c1944a8e7311be8e6e
[2]: https://github.com/tarantool/tarantool/issues/6034

Fixes #92

----

Sorry, I don't know how to run it to test the changes. It is blind
attempt to fix the problem. I would appreciate a help.