### PR TITLE
Enable uberjar support and build uberjar in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,3 +36,5 @@ jobs:
     - run: lein check
 
     - run: lein compile
+
+    - run: lein uberjar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,4 @@ change log follows the conventions of
 - Add basic nemesis faults support.
 - Add primary node discovery (#43, #17).
 - Add bank workload (#67).
+- Enable uberjar support and build JAR file in CI.

--- a/project.clj
+++ b/project.clj
@@ -13,4 +13,4 @@
   :plugins [[lein-cljfmt "0.6.8"]]
   :repl-options {:init-ns tarantool.runner}
   :jvm-opts ["-Djava.awt.headless=true -Xmx12G"]
-  )
+  :aot [tarantool.runner])

--- a/src/tarantool/runner.clj
+++ b/src/tarantool/runner.clj
@@ -23,7 +23,8 @@
                        [nemesis :as nemesis]
                        [register :as register]
                        [sets :as sets]
-                       [counter :as counter]]))
+                       [counter :as counter]])
+   (:gen-class))
 
 (def minimal-concurrency
   10)


### PR DESCRIPTION
Now for running Jepsen tests one need to setup build environment that
includes Leiningen and Clojure, clone GIT repository and know how to
properly build and run tests. It is not convenient for those who are not
familiar with Clojure and don't want to make a patches for Jepsen tests.
However Leiningen allows to build a standalone jar file, that requires
only JVM for running:

```bash
$ lein uberjar
Compiling tarantool.runner
Created /home/sergeyb/sources/MRG/jepsen.tarantool/target/jepsen.tarantool-0.1.0.jar
Created /home/sergeyb/sources/MRG/jepsen.tarantool/target/jepsen.tarantool-0.1.0-standalone.jar
$ java -jar target/jepsen.tarantool-0.1.0-standalone.jar
Usage: lein run -- COMMAND [OPTIONS ...]
Commands: analyze, serve, test, test-all
```

1. https://github.com/technomancy/leiningen/blob/master/doc/TUTORIAL.md#uberjar

Related to #97
Follows up https://github.com/tarantool/tarantool/issues/5277