### PR TITLE
Make spaces synchronous in a bank tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ change log follows the conventions of
 - Enable :primaries for partition, kill and pause nemeses (#59).
 - Fix test bank with accounts in separate tables.
 - Mark a singleton instance as a leader manually (#92).
+- Enable synchronous mode for spaces in bank tests.
 
 ### Changed
 

--- a/src/tarantool/bank.clj
+++ b/src/tarantool/bank.clj
@@ -43,6 +43,9 @@
            (j/execute! conn [(str "CREATE TABLE IF NOT EXISTS " table-name
                              "(id INT NOT NULL PRIMARY KEY,
                              balance INT NOT NULL)")])
+           (j/execute! conn [(str "SELECT LUA('return box.space."
+                                  (clojure.string/upper-case table-name)
+                                  ":alter{ is_sync = true } or 1')")])
            (doseq [a (:accounts test)]
                (info "Populating account")
                (sql/insert! conn table-name
@@ -103,6 +106,9 @@
                                        "(id             INT NOT NULL PRIMARY KEY,"
                                        "account_id      INT NOT NULL,"
                                        "balance INT NOT NULL)")])
+                (j/execute! conn [(str "SELECT LUA('return box.space."
+                                       (clojure.string/upper-case (str table-name a))
+                                       ":alter{ is_sync = true } or 1')")])
                   (info "Populating account" a)
                   (sql/insert! conn (str table-name a)
                       {:id 0
@@ -174,6 +180,9 @@
            (j/execute! conn [(str "CREATE TABLE IF NOT EXISTS " table-name
                              "(id INT NOT NULL PRIMARY KEY,
                              balance INT NOT NULL)")])
+           (j/execute! conn [(str "SELECT LUA('return box.space."
+                                  (clojure.string/upper-case table-name)
+                                  ":alter{ is_sync = true } or 1')")])
            (doseq [a (:accounts test)]
                (info "Populating account")
                    (sql/insert! conn table-name
@@ -243,6 +252,9 @@
                 (j/execute! conn [(str "CREATE TABLE IF NOT EXISTS " table-name a
                                        "(id     INT NOT NULL PRIMARY KEY,"
                                        "balance INT NOT NULL)")])
+                (j/execute! conn [(str "SELECT LUA('return box.space."
+                                       (clojure.string/upper-case (str table-name a))
+                                       ":alter{ is_sync = true } or 1')")])
                   (info "Populating account" a)
                   (sql/insert! conn (str table-name a)
                       {:id 0


### PR DESCRIPTION
Accidentally option for enabling synchronous mode for spaces in bank
tests was not used. It means that with Tarantool cluster we tested
asynchronous replication that has lower consistency guarantess that
synchronous (eventual consistency). This patch enables is_sync for all
spaces used in bank tests.

For other tests option "is_sync" was enabled in commit "Make spaces used
in tests synchronous" (dfb4d45d32baf175e457ae431899a0e8ca098c75).

Follows up #51